### PR TITLE
typo in cmd help

### DIFF
--- a/bin/bb
+++ b/bin/bb
@@ -20,7 +20,7 @@ program.set({
         var title = chalk.bold;
         var r = '  ' + title('Version') + ': ' + pkg.version;
         r += '\n\n  ' + title('Usage') + ': bb <command> [OPTIONS]';
-        r += '\n\n  ' + title('Commands') + ': achetype (arch), export, import, import-item, import-collection, generate, rest, sync, ln, install.';
+        r += '\n\n  ' + title('Commands') + ': archetype (arch), export, import, import-item, import-collection, generate, rest, sync, ln, install.';
         r += '\n\n';
         return r;
     }


### PR DESCRIPTION
'achetype' is 'archetype'. 