### PR TITLE
Added check for exclude inside of getDir function that will set to an …

### DIFF
--- a/lib/getDir.js
+++ b/lib/getDir.js
@@ -6,6 +6,7 @@ var _ = require('lodash');
 // returns list of items in dir
 // file names
 module.exports = function(dirPath, exclude) {
+    exclude = exclude || [];
     dirPath = path.resolve(dirPath);
     return fs.readdirAsync(dirPath)
     .then(_.partial(parseItems, dirPath, _, exclude))


### PR DESCRIPTION
…array if it is undefined

Changes made so that calling getDir(path) does not result in an error. If no files are set to be excluded, the exclude variable is set to [] inside of the getDir function