### PR TITLE
Check connectivity before fetching ng lite widget

### DIFF
--- a/lib/checkGithubConnectivity.js
+++ b/lib/checkGithubConnectivity.js
@@ -1,13 +1,13 @@
 var Q = require('q');
 var dns = require('dns');
 
-module.exports = function (repoUrl) {
+module.exports = function () {
     var deferred = Q.defer();
     dns.resolve('github.com', function (err) {
         if (err) {
             deferred.reject(err);
         } else {
-            deferred.resolve(repoUrl);
+            deferred.resolve();
         }
     });
     return deferred.promise;

--- a/lib/checkGithubConnectivity.js
+++ b/lib/checkGithubConnectivity.js
@@ -1,0 +1,14 @@
+var Q = require('q');
+var dns = require('dns');
+
+module.exports = function (repoUrl) {
+    var deferred = Q.defer();
+    dns.resolve('github.com', function (err) {
+        if (err) {
+            deferred.reject(err);
+        } else {
+            deferred.resolve(repoUrl);
+        }
+    });
+    return deferred.promise;
+};

--- a/lib/downloadLatestTemplates.js
+++ b/lib/downloadLatestTemplates.js
@@ -1,0 +1,43 @@
+var path = require('path');
+var walk = require('walk');
+var repos = require('../templates/repos.json');
+
+var bbscaff = require('../lib/bbscaff');
+var checkGithubConnectivity = require('./checkGithubConnectivity');
+
+var templatesDir = path.join(__dirname, '..', 'templates');
+
+var walker = walk.walk(templatesDir);
+
+checkGithubConnectivity()
+    .then(
+        function () {
+            var repoTemplates = [];
+            walker
+                .on("names", function (root, nodeNamesArray, next) {
+                    var name = '';
+                    if (nodeNamesArray.indexOf('bbscaff.js') !== -1) {
+                        name = root.replace(templatesDir + '/', '');
+                        if (repos[name]) {
+                            repoTemplates.push({
+                                repo: repos[name],
+                                path: root
+                            });
+                        }
+                    }
+                    next();
+                })
+                .on("end", function () {
+                    repoTemplates.forEach(function (data) {
+                        bbscaff.fetchTemplate(data.repo, data.path, function (err) {
+                            if (err) {
+                                return console.error('Error trying to update template from git', err);
+                            }
+                        });
+                    });
+                });
+        },
+        function (err) {
+            console.log('Error trying to update template from git', err);
+        }
+    );

--- a/package.json
+++ b/package.json
@@ -1,82 +1,84 @@
 {
-  "name": "bb-cli",
-  "version": "0.2.4-beta.3",
-  "description": "Command line tools for working with Backbase CXP.",
-  "author": "Backbase",
-  "licenses": [
-    {
-      "type": "Apache-2.0",
-      "url": "http://www.apache.org/licenses/LICENSE-2.0"
+    "name": "bb-cli",
+    "version": "0.2.4-beta.3",
+    "description": "Command line tools for working with Backbase CXP.",
+    "author": "Backbase",
+    "licenses": [
+        {
+            "type": "Apache-2.0",
+            "url": "http://www.apache.org/licenses/LICENSE-2.0"
+        }
+    ],
+    "preferGlobal": "true",
+    "scripts": {
+        "test": "gulp",
+        "postinstall": "node ./lib/downloadLatestTemplates.js"
+    },
+    "bin": {
+        "bb": "bin/bb"
+    },
+    "dependencies": {
+        "acorn": "^0.11.0",
+        "bower": "^1.5.3",
+        "bower-config": "^1.2.0",
+        "chalk": "^1.1.1",
+        "cli-table": "^0.3.1",
+        "clui": "^0.3.1",
+        "cross-spawn": "^0.2.6",
+        "decompress-zip": "^0.2.0",
+        "escodegen": "^1.4.3",
+        "formattor": "0.0.2",
+        "fs-extra-promise": "^0.3.0",
+        "fs-finder": "^1.8.0",
+        "gift": "^0.6.1",
+        "glob": "~5.0.3",
+        "gulp": "^3.8.8",
+        "gulp-conflict": "^0.2.0",
+        "gulp-debug": "^2.1.0",
+        "gulp-filter": "^1.0.2",
+        "gulp-if": "^1.2.5",
+        "gulp-less": "^3.0.3",
+        "gulp-minify-css": "^1.2.0",
+        "gulp-mq-remove": "0.0.2",
+        "gulp-rename": "^1.2.0",
+        "gulp-rework": "^1.0.3",
+        "gulp-sourcemaps": "^1.5.2",
+        "gulp-template": "^1.1.1",
+        "inquirer": "^0.10.1",
+        "jszip": "^2.5.0",
+        "jxon": "^1.4.0",
+        "lodash": "^3.2.0",
+        "map-stream": "0.0.5",
+        "moment": "^2.10.6",
+        "mosaic-rest-js": "^0.4.0",
+        "node-fs-extra": "^0.8.1",
+        "object-assign": "^3.0.0",
+        "osenv": "^0.1.3",
+        "q": "^1.1.2",
+        "request-promise": "^0.4.3",
+        "ronin": "^0.3.11",
+        "semver": "^5.0.1",
+        "through2": "^2.0.0",
+        "tmp": "^0.0.28",
+        "walk": "^2.3.9",
+        "watch": "^0.16.0"
+    },
+    "main": "lib",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/Backbase/bb-cli.git"
+    },
+    "bugs": {
+        "url": "https://github.com/Backbase/bb-cli/issues"
+    },
+    "homepage": "https://github.com/Backbase/bb-cli/tree/nightly",
+    "devDependencies": {
+        "gulp-jscs": "^1.4.0",
+        "gulp-jshint": "^1.9.2",
+        "gulp-mocha": "^2.0.1",
+        "jshint-stylish": "^1.0.1",
+        "mocha": "^2.0.1",
+        "pre-commit": "^1.0.7",
+        "should": "^4.3.0"
     }
-  ],
-  "preferGlobal": "true",
-  "scripts": {
-    "test": "gulp"
-  },
-  "bin": {
-    "bb": "bin/bb"
-  },
-  "dependencies": {
-    "acorn": "^0.11.0",
-    "bower": "^1.5.3",
-    "bower-config": "^1.2.0",
-    "chalk": "^1.1.1",
-    "cli-table": "^0.3.1",
-    "clui": "^0.3.1",
-    "cross-spawn": "^0.2.6",
-    "decompress-zip": "^0.2.0",
-    "escodegen": "^1.4.3",
-    "formattor": "0.0.2",
-    "fs-extra-promise": "^0.3.0",
-    "fs-finder": "^1.8.0",
-    "gift": "^0.6.1",
-    "glob": "~5.0.3",
-    "gulp": "^3.8.8",
-    "gulp-conflict": "^0.2.0",
-    "gulp-debug": "^2.1.0",
-    "gulp-filter": "^1.0.2",
-    "gulp-if": "^1.2.5",
-    "gulp-less": "^3.0.3",
-    "gulp-minify-css": "^1.2.0",
-    "gulp-mq-remove": "0.0.2",
-    "gulp-rename": "^1.2.0",
-    "gulp-rework": "^1.0.3",
-    "gulp-sourcemaps": "^1.5.2",
-    "gulp-template": "^1.1.1",
-    "inquirer": "^0.10.1",
-    "jszip": "^2.5.0",
-    "jxon": "^1.4.0",
-    "lodash": "^3.2.0",
-    "map-stream": "0.0.5",
-    "moment": "^2.10.6",
-    "mosaic-rest-js": "^0.4.0",
-    "node-fs-extra": "^0.8.1",
-    "object-assign": "^3.0.0",
-    "osenv": "^0.1.3",
-    "q": "^1.1.2",
-    "request-promise": "^0.4.3",
-    "ronin": "^0.3.11",
-    "semver": "^5.0.1",
-    "through2": "^2.0.0",
-    "tmp": "^0.0.28",
-    "watch": "^0.16.0"
-  },
-  "main": "lib",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/Backbase/bb-cli.git"
-  },
-  "bugs": {
-    "url": "https://github.com/Backbase/bb-cli/issues"
-  },
-  "homepage": "https://github.com/Backbase/bb-cli/tree/nightly",
-  "devDependencies": {
-    "gulp-jscs": "^1.4.0",
-    "gulp-jshint": "^1.9.2",
-    "gulp-mocha": "^2.0.1",
-    "jshint-stylish": "^1.0.1",
-    "mocha": "^2.0.1",
-    "pre-commit": "^1.0.7",
-    "should": "^4.3.0"
-  }
 }

--- a/templates/lp-module/bbscaff.js
+++ b/templates/lp-module/bbscaff.js
@@ -37,12 +37,28 @@ module.exports = function(bbscaff){
         checkGithubConnectivity()
             .then(
                 function (){
-                    bbscaff.fetchTemplate(repos['lp-module'], __dirname, function(err){
-                        if (err) {
-                            return console.error('Error trying to update template from git', err);
+                    bbscaff.prompt([
+                            {
+                                type: 'input',
+                                name: 'update',
+                                message: 'There is a new version of the template. Do you want to update it?',
+                                default: 'Y'
+                            }
+                        ],
+                        function(data){
+                            if(data.update.toUpperCase() === 'N'){
+                                generate(answers);
+                            }else {
+                                console.log('Updating template.');
+                                bbscaff.fetchTemplate(repos['lp-module'], __dirname, function(err){
+                                    if (err) {
+                                        return console.error('Error trying to update template from git', err);
+                                    }
+                                    generate(answers);
+                                });
+                            }
                         }
-                        generate(answers);
-                    });
+                    );
                 },
                 function (err) {
                     generate(answers);

--- a/templates/lp-module/bbscaff.js
+++ b/templates/lp-module/bbscaff.js
@@ -1,4 +1,19 @@
+var checkGithubConnectivity = require('../../lib/checkGithubConnectivity');
+var repos = require("../repos.json");
+
 module.exports = function(bbscaff){
+    var generate = function (answers) {
+        bbscaff.generate({
+            // LP uses widget.name instead of widget_name
+            module: answers
+        }, {
+            // Sets destination path
+            destination_path: answers.name,
+            // Reset interpolate from bbscaff, so instead of <%=var%> it uses ${var}
+            interpolate: undefined
+        });
+    };
+
     bbscaff.prompt([
         {
             type: 'input',
@@ -19,20 +34,19 @@ module.exports = function(bbscaff){
             message: 'Author'
         }
     ], function(answers){
-        bbscaff.fetchTemplate('http://bitbucket.org/backbase/lp-module-blank-template.git', __dirname, function(err){
-            if (err) {
-                return console.error('Error trying to update template from git', err);
-            }
-
-            bbscaff.generate({
-                // LP uses widget.name instead of widget_name
-                module: answers
-            }, {
-                // Sets destination path
-                destination_path: answers.name,
-                // Reset interpolate from bbscaff, so instead of <%=var%> it uses ${var}
-                interpolate: undefined
-            });
-        });
+        checkGithubConnectivity()
+            .then(
+                function (){
+                    bbscaff.fetchTemplate(repos['lp-module'], __dirname, function(err){
+                        if (err) {
+                            return console.error('Error trying to update template from git', err);
+                        }
+                        generate(answers);
+                    });
+                },
+                function (err) {
+                    generate(answers);
+                }
+            );
     });
 };

--- a/templates/lp-widget/bbscaff.js
+++ b/templates/lp-widget/bbscaff.js
@@ -1,4 +1,18 @@
+var checkGithubConnectivity = require('../../lib/checkGithubConnectivity');
+var repos = require('../repos.json');
+
 module.exports = function(bbscaff){
+    var generate = function (answers) {
+        bbscaff.generate({
+            // LP uses widget.name instead of widget_name
+            widget: answers
+        }, {
+            // Sets destination path
+            destination_path: answers.name,
+            // Reset interpolate from bbscaff, so instead of <%=var%> it uses ${var}
+            interpolate: undefined
+        });
+    };
     bbscaff.prompt([
         {
             type: 'input',
@@ -19,20 +33,20 @@ module.exports = function(bbscaff){
             message: 'Author'
         }
     ], function(answers){
-        bbscaff.fetchTemplate('http://bitbucket.org/backbase/lp-widget-ng-template.git', __dirname, function(err){
-            if (err) {
-                return console.error('Error trying to update template from git', err);
-            }
+        checkGithubConnectivity()
+            .then(
+                function (){
+                    bbscaff.fetchTemplate(repos['lp-widget'], __dirname, function(err){
+                        if (err) {
+                            return console.error('Error trying to update template from git', err);
+                        }
+                        generate(answers);
+                    });
+                },
+                function (err) {
+                    generate(answers);
+                }
+            );
 
-            bbscaff.generate({
-                // LP uses widget.name instead of widget_name
-                widget: answers
-            }, {
-                // Sets destination path
-                destination_path: answers.name,
-                // Reset interpolate from bbscaff, so instead of <%=var%> it uses ${var}
-                interpolate: undefined
-            });
-        });
     });
 };

--- a/templates/lp-widget/bbscaff.js
+++ b/templates/lp-widget/bbscaff.js
@@ -36,12 +36,28 @@ module.exports = function(bbscaff){
         checkGithubConnectivity()
             .then(
                 function (){
-                    bbscaff.fetchTemplate(repos['lp-widget'], __dirname, function(err){
-                        if (err) {
-                            return console.error('Error trying to update template from git', err);
+                    bbscaff.prompt([
+                            {
+                                type: 'input',
+                                name: 'update',
+                                message: 'There is a new version of the template. Do you want to update it?',
+                                default: 'false'
+                            }
+                        ],
+                        function(data){
+                            if(data.update === 'false'){
+                                generate(answers);
+                            }else {
+                                console.log('Updating template.');
+                                bbscaff.fetchTemplate(repos['lp-widget'], __dirname, function(err){
+                                    if (err) {
+                                        return console.error('Error trying to update template from git', err);
+                                    }
+                                    generate(answers);
+                                });
+                            }
                         }
-                        generate(answers);
-                    });
+                    );
                 },
                 function (err) {
                     generate(answers);

--- a/templates/repos.json
+++ b/templates/repos.json
@@ -1,0 +1,5 @@
+{
+    "lp-module": "http://bitbucket.org/backbase/lp-module-blank-template.git",
+    "lp-widget": "https://bitbucket.org/backbase/lpg-generator-widget-ng",
+    "widget": "https://bitbucket.org/backbase/lpg-generator-widget-ng-lite.git"
+}

--- a/templates/widget/bbscaff.js
+++ b/templates/widget/bbscaff.js
@@ -41,12 +41,28 @@ module.exports = function(bbscaff){
         checkGithubConnectivity()
             .then(
                 function () {
-                    bbscaff.fetchTemplate(repos.widget, __dirname, function(err){
-                        if (err) {
-                            return console.error('Error trying to update template from git', err);
+                    bbscaff.prompt([
+                            {
+                                type: 'input',
+                                name: 'update',
+                                message: 'There is a new version of the template. Do you want to update it?',
+                                default: 'false'
+                            }
+                        ],
+                        function(data){
+                            if(data.update === 'false'){
+                                generate(answers);
+                            }else {
+                                console.log('Updating template.');
+                                bbscaff.fetchTemplate(repos.widget, __dirname, function(err){
+                                    if (err) {
+                                        return console.error('Error trying to update template from git', err);
+                                    }
+                                    generate(answers);
+                                });
+                            }
                         }
-                        generate(answers);
-                    });
+                    );
                 },
                 function (err) {
                     generate(answers);

--- a/templates/widget/bbscaff.js
+++ b/templates/widget/bbscaff.js
@@ -1,8 +1,13 @@
 var checkGithubConnectivity = require('../../lib/checkGithubConnectivity');
+var repos = require('../repos.json');
 
-console.log('This widget is not compatible with CXP 5.6');
+console.log('This widget could be not compatible with CXP 5.6');
 
 module.exports = function(bbscaff){
+    var generate = function (answers) {
+        bbscaff.generate(answers, answers.widget_name);
+    };
+
     bbscaff.prompt([
         {
             type: 'input',
@@ -33,18 +38,18 @@ module.exports = function(bbscaff){
             }
         }
     ], function(answers){
-        checkGithubConnectivity('https://bitbucket.org/backbase/lpg-generator-widget-ng-lite.git')
+        checkGithubConnectivity()
             .then(
-                function (repoUrl) {
-                    bbscaff.fetchTemplate(repoUrl, __dirname, function(err){
+                function () {
+                    bbscaff.fetchTemplate(repos.widget, __dirname, function(err){
                         if (err) {
                             return console.error('Error trying to update template from git', err);
                         }
-                        bbscaff.generate(answers, answers.widget_name);
+                        generate(answers);
                     });
                 },
                 function (err) {
-                    bbscaff.generate(answers, answers.widget_name);
+                    generate(answers);
                 }
             );
 

--- a/templates/widget/bbscaff.js
+++ b/templates/widget/bbscaff.js
@@ -1,3 +1,5 @@
+var checkGithubConnectivity = require('../../lib/checkGithubConnectivity');
+
 console.log('This widget is not compatible with CXP 5.6');
 
 module.exports = function(bbscaff){
@@ -31,6 +33,20 @@ module.exports = function(bbscaff){
             }
         }
     ], function(answers){
-        bbscaff.generate(answers, answers.widget_name);
+        checkGithubConnectivity('https://bitbucket.org/backbase/lpg-generator-widget-ng-lite.git')
+            .then(
+                function (repoUrl) {
+                    bbscaff.fetchTemplate(repoUrl, __dirname, function(err){
+                        if (err) {
+                            return console.error('Error trying to update template from git', err);
+                        }
+                        bbscaff.generate(answers, answers.widget_name);
+                    });
+                },
+                function (err) {
+                    bbscaff.generate(answers, answers.widget_name);
+                }
+            );
+
     });
 };


### PR DESCRIPTION
This pull-request adds some features to the tool:
* When the user has installed the bb-cli tool it will download the latest versions of templates.
  * Installing the bb-cli tool, normally, requires to have an internet connection so we use it.
* Each time the user ask to generate a new item it will check if there is a new version available.
  * It there is a new version available it will ask the user if he/she wants to download it and replace the old one or if he/she wants to keep the old version.
* In all the cases if there is no internet connection available it will generate the item from the latest template stored locally.