### PR TITLE
Fix target-arg parameter parsing

### DIFF
--- a/commands/rest.js
+++ b/commands/rest.js
@@ -71,7 +71,7 @@ module.exports = Command.extend({
 
             if (cfg.info) logInfo(bbrest.config);
 
-            cfg.targetArg = tryParseJSON(cfg.targetArg) || [cfg.targetArg];
+            cfg.targetArg = tryParseJSON(cfg['target-arg']) || [cfg['target-arg']];
             cfg.file = tryParseJSON(cfg.file) || cfg.file;
             cfg.query = tryParseJSON(cfg.query);
 


### PR DESCRIPTION
When trying to change rights of a widget, widget name was missing because ```target-arg``` was not read from cli parameters correctly.

    bb rest --host cxp56-sb.backbasecloud.com --port 80 --portal retail-banking --target widget --target-arg widget-accounts --method put --rights --file ./rights.xml --verbose --username admin --password admin

