### PR TITLE
Fix error reporting on import-item.

### DIFF
--- a/commands/import-item.js
+++ b/commands/import-item.js
@@ -225,9 +225,16 @@ function addZeroVersion(model) {
 function output() {
     if (cfg.verbose) console.log.apply(this, arguments);
 }
+
 function error(err, model) {
-    util.err(chalk.red((model.getName() || '')) + ' ' + (err.message || err.error));
+    var errMessage = err.message || err.error;
+    if (model && model.getName()) {
+        errMessage = chalk.red(model.getName()) + errMessage;
+    }
+
+    util.err(errMessage);
 }
+
 function ok(r, name) {
     util.ok(chalk.yellow(name) + ' imported');
     return r;


### PR DESCRIPTION
When running import-item when portal is not running, model is not defined, so it just
exits without any error.