### PR TITLE
Add ability to have multiple profiles in the .bbrc

### DIFF
--- a/commands/rest.js
+++ b/commands/rest.js
@@ -62,7 +62,6 @@ module.exports = Command.extend({
     },
 
     run: function () {
-
         return config.getCommon(this.options)
         .then(function(r) {
             bbrest = r.bbrest;
@@ -99,7 +98,7 @@ function tryParseJSON (jsonString){
         // Neither JSON.parse(false) or JSON.parse(1234) throw errors, hence the type-checking,
         // but... JSON.parse(null) returns 'null', and typeof null === "object",
         // so we must check for that, too.
-        if (o && typeof o === "object" && o !== null) {
+        if (o && typeof o === 'object' && o !== null) {
             return o;
         }
     }

--- a/docs/lib.config.md
+++ b/docs/lib.config.md
@@ -76,7 +76,15 @@ config.absolutizePath()
   "username": "john",
   "password": "HU&69wev*!$8",
   "portal": "myportal",
-  "path": "/path/to/the/portalserver"
+  "path": "/path/to/the/portalserver",
+  "profiles": {
+    "dev": {
+      "host": "my-host.backbase.dev",
+      "port": "80",
+      "username": "username",
+      "password": "password"
+    }
+  }
 }
 ```
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -15,7 +15,7 @@ exports.get = function (cliConfig) {
         exports.getBb(),
         exports.getBower(),
         exports.getBowerRc(),
-        exports.getBbRc()
+        exports.getBbRc(cliConfig)
     ];
 
     return Q.all(a)
@@ -56,16 +56,22 @@ exports.getBowerRc = function () {
         });
 };
 
-exports.getBbRc = function () {
+exports.getBbRc = function (cliConfig) {
+    var profile = cliConfig && cliConfig.profile || process.env.BBPROFILE;
+
     iniDir = process.cwd();
     return getNested('.bbrc', [], 100)
-    .then(function(r) {
-        if (r.path) r.path = exports.absolutizePath(r.path);
-        return r;
-    })
-    .catch(function() {
-        return {};
-    });
+        .then(function(r) {
+            if (profile && r.profiles && r.profiles[profile]) {
+                // if profile exist, extend bbrc with profile properties
+                _.merge(r, r.profiles[profile]);
+            }
+            if (r.path) r.path = exports.absolutizePath(r.path);
+            return r;
+        })
+        .catch(function() {
+            return {};
+        });
 };
 
 exports.absolutizePath = function (pth) {


### PR DESCRIPTION
Example of .bbrc file:
```
{
    "scheme": "http",
    "host": "localhost",
    "context": "portalserver",
    "port": "80",
    "username": "admin",
    "password": "admin",
    "profiles": {
        "dev": {
            "host": "winter-water-81-dbp.backbase.dev"
        }
    }
}

```
Profile properties will be merged to the root level properties.

Usage: 
`bb import-item --profile=dev`

or save it as environment variable:
export BBPROFILE=dev

and use without using profile flag:
`bb import-item`
